### PR TITLE
feature: allow conditional creation of ServiceAccount

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "0.4.4"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:
@@ -15,5 +15,3 @@ sources:
 maintainers:
 - name: OpsLevel
   email: support@opslevel.com
-
-

--- a/charts/kubernetes-sync/templates/serviceaccount.yaml
+++ b/charts/kubernetes-sync/templates/serviceaccount.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -17,7 +19,7 @@ rules:
 - apiGroups:
   - ""
   - "*"
-  resources: 
+  resources:
   - "*"
   verbs:
   - get
@@ -36,3 +38,4 @@ roleRef:
   kind: ClusterRole
   name: sync
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -30,6 +30,7 @@ sync:
 
 
 serviceAccount:
+  create: true
   name: "opslevel-sync"
 
 


### PR DESCRIPTION
So that the user can user their own ServiceAccount with such a values file:

```
serviceAccount:
  create: false
  name: my-sa
```

This allows the user to fine-tune the RBAC permissions, which is useful especially given the current default ClusterRole allows reading `Secret` objects.