### PR TITLE
feature: support init containers and the filesystem as an alternative…

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.3.4
-appVersion: "0.4.4"
+version: 0.3.5
+appVersion: "0.4.7"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:
 - monitoring

--- a/charts/kubernetes-sync/templates/configmap.yaml
+++ b/charts/kubernetes-sync/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sync
+  name: {{ template "opslevel-sync.fullname" . }}
   labels:
     {{- include "opslevel-sync.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
@@ -11,3 +11,6 @@ metadata:
 data:
   opslevel-k8s.yaml: |-
     {{ .Values.sync.config | nindent 4 }}
+  {{- with .Values.additionalConfigMapData }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/kubernetes-sync/templates/cronjob.yaml
+++ b/charts/kubernetes-sync/templates/cronjob.yaml
@@ -42,7 +42,7 @@ spec:
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
             securityContext:
-              {{- toYaml .Values.podSecurityContext | nindent 14 }}
+              {{- toYaml .Values.securityContext | nindent 14 }}
             volumeMounts:
             - name: config
               mountPath: /app

--- a/charts/kubernetes-sync/templates/cronjob.yaml
+++ b/charts/kubernetes-sync/templates/cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: sync
+  name: {{ template "opslevel-sync.fullname" . }}
   labels:
     {{- include "opslevel-sync.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
@@ -16,6 +16,10 @@ spec:
         spec:
           restartPolicy: Never
           serviceAccountName: {{ include "opslevel-sync.serviceAccountName" . }}
+          initContainers:
+            {{- with .Values.additionalInitContainers }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           containers:
           - name: {{ .Chart.Name }}
             image: {{ .Values.image }}
@@ -23,9 +27,15 @@ spec:
             args:
               - service
               - import
+              {{- if .Values.apitokenPath }}
+              - --api-token-path
+              - {{ .Values.apitokenPath }}
+              {{- end }}
             envFrom:
+            {{- if and .Values.apitokenSecret.create (not .Values.apitokenPath) }}
             - secretRef:
-                name: api-token
+                name: {{ .Values.apitokenSecret.name }}
+            {{- end }}
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
             securityContext:
@@ -33,10 +43,16 @@ spec:
             volumeMounts:
             - name: config
               mountPath: /app
+            {{- with .Values.additionalVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumes:
           - name: config
             configMap:
               name: sync
+          {{- with .Values.additionalVolumes }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/kubernetes-sync/templates/cronjob.yaml
+++ b/charts/kubernetes-sync/templates/cronjob.yaml
@@ -27,6 +27,9 @@ spec:
             args:
               - service
               - import
+              {{- with .Values.sync.args }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
               {{- if .Values.apitokenPath }}
               - --api-token-path
               - {{ .Values.apitokenPath }}

--- a/charts/kubernetes-sync/templates/secret.yaml
+++ b/charts/kubernetes-sync/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.apitokenSecret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: api-token
+  name: {{ .Values.apitokenSecret.name }}
   labels:
     {{- include "opslevel-sync.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
@@ -11,3 +12,4 @@ metadata:
 type: opaque
 data:
   OL_APITOKEN: {{ .Values.apitoken | b64enc | quote }}
+{{- end }}

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -9,6 +9,8 @@ image: public.ecr.aws/opslevel/kubectl-opslevel:v0.4.7
 sync:
   schedule: "0 12 * * 1"
   # You can use helm's `--set-file sync.config=./opslevel-k8s.yaml` to populate this
+  args:
+  #- --log-level=DEBUG
   config: |-
     version: "1.1.0"
     service:

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -1,4 +1,4 @@
-apitoken: "WsguaBJvd44nT2EwFn1bQQIGq9aK7tNA84FI"
+apitoken:
 apitokenPath:
 apitokenSecret:
   create: true

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -1,6 +1,10 @@
 apitoken: "WsguaBJvd44nT2EwFn1bQQIGq9aK7tNA84FI"
+apitokenPath:
+apitokenSecret:
+  create: true
+  name: api-token
 
-image: public.ecr.aws/opslevel/kubectl-opslevel:v0.4.4
+image: public.ecr.aws/opslevel/kubectl-opslevel:v0.4.7
 
 sync:
   schedule: "0 12 * * 1"
@@ -28,11 +32,14 @@ sync:
               create: # tag with the same key name but with a different value with be added to the service
                 - '{"environment": .spec.template.metadata.labels.environment}'
 
-
 serviceAccount:
   create: true
   name: "opslevel-sync"
 
+additionalConfigMapData:
+additionalInitContainers:
+additionalVolumes:
+additionalVolumeMounts:
 
 # File Wide Settings
 nameOverride: ""


### PR DESCRIPTION
… way to fetch the API token

# Example Usage

```yaml
# fake-values.yaml
---
nameOverride: opslevel-kubernetes-reconcile

# Read the token from the filesystem. Disable creating a Kubernetes Secret.
apitokenPath: /path/to/secrets/opslevel-api-token.txt
apitokenSecret:
  create: false

# Roll your own ServiceAccount + RBAC.
serviceAccount:
  create: false
  name: my-custom-service-account

# ConfigMaps mounted as volumes are read-only so we need to be able to create additional ones for the
# initcontainer to write to.
additionalVolumes:
- name: secrets
  emptyDir:
    medium: memory
additionalVolumeMounts:
- name: secrets
  mountPath: /path/to/secrets/

# Bootstrapping prior to app start occurs in these containers.
additionalInitContainers:
- name: secrets-init
  image: my.registry.com/me/secret-fetch:123
  resources:
    limits:
      cpu: 1
      memory: 200Mi
    requests:
      cpu: 0.1
      memory: 64Mi
  command:
  - init
  - --config
  - /app/secret-fetch-config.yaml
  volumeMounts:
  - name: secrets
    mountPath: /path/to/secrets
  - name: config
    mountPath: /app/

# If init containers require configuration it can be included here so it is mounted in the `/app/` dir.
additionalConfigMapData:
  secret-fetch-config.yaml: |-
    ---
    version: 1
    secrets:
    - name: opslevel
      key: api-token
      output: /path/to/secrets/opslevel-api-token.txt
```

```bash
# Render the chart instead of installing so we can see the resulting manifests.
helm template opslevel-kubernetes-reconcile . --namespace=default -f fake-values.yaml
```

Resulting manifests:

```yaml
---
# Source: kubernetes-sync/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: opslevel-kubernetes-reconcile
  labels:
    helm.sh/chart: kubernetes-sync-0.3.4
    app.kubernetes.io/name: opslevel-kubernetes-reconcile
    app.kubernetes.io/instance: opslevel-kubernetes-reconcile
    app.kubernetes.io/version: "0.4.4"
    app.kubernetes.io/managed-by: Helm
  annotations:
    opslevel.com/description: A tool that enables you to import & reconcile services with
      OpsLevel from your Kubernetes clusters.
    opslevel.com/language: go
    opslevel.com/tags.app_version: v0.3.0.beta1
data:
  opslevel-k8s.yaml: |-
    
    version: "1.1.0"
    service:
      import:
        - selector: # This limits what data we look at in Kubernetes
            apiVersion: apps/v1 # only supports resources found in 'kubectl api-resources --verbs="get,list"'
            kind: Deployment
            excludes: # filters out resources if any expression returns truthy
              - .metadata.namespace == "kube-system"
              - .metadata.namespace == "local-path-storage"
              - .metadata.annotations."opslevel.com/ignore"
          opslevel: # This is how you map your kubernetes data to opslevel service
            name: .metadata.name
            owner: .metadata.namespace
            aliases: # This are how we identify the services again during reconciliation - please make sure they are very unique
              - '"k8s:\(.metadata.name)-\(.metadata.namespace)"'
            tags:
              assign: # tag with the same key name but with a different value will be updated on the service
                - '{"imported": "kubectl-opslevel"}'
                - .spec.template.metadata.labels
              create: # tag with the same key name but with a different value with be added to the service
                - '{"environment": .spec.template.metadata.labels.environment}'
  secret-fetch-config.yaml: |-
    ---
    version: 1
    secrets:
    - name: opslevel
      key: api-token
      output: /path/to/secrets/opslevel-api-token.txt
---
# Source: kubernetes-sync/templates/cronjob.yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: opslevel-kubernetes-reconcile
  labels:
    helm.sh/chart: kubernetes-sync-0.3.4
    app.kubernetes.io/name: opslevel-kubernetes-reconcile
    app.kubernetes.io/instance: opslevel-kubernetes-reconcile
    app.kubernetes.io/version: "0.4.4"
    app.kubernetes.io/managed-by: Helm
  annotations:
    opslevel.com/description: A tool that enables you to import & reconcile services with
      OpsLevel from your Kubernetes clusters.
    opslevel.com/language: go
    opslevel.com/tags.app_version: v0.3.0.beta1
spec:
  schedule: "0 12 * * 1"
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: Never
          serviceAccountName: my-custom-service-account
          initContainers:
            - command:
              - init
              - --config
              - /app/secret-fetch-config.yaml
              image: my.registry.com/me/secret-fetch:123
              name: secrets-init
              resources:
                limits:
                  cpu: 1
                  memory: 200Mi
                requests:
                  cpu: 0.1
                  memory: 64Mi
              volumeMounts:
              - mountPath: /path/to/secrets
                name: secrets
              - mountPath: /app/
                name: config
          containers:
          - name: kubernetes-sync
            image: public.ecr.aws/opslevel/kubectl-opslevel:v0.4.7
            imagePullPolicy: IfNotPresent
            args:
              - service
              - import
              - --api-token-path
              - /path/to/secrets/opslevel-api-token.txt
            envFrom:
            resources:
              {}
            securityContext:
              null
            volumeMounts:
            - name: config
              mountPath: /app
            - mountPath: /path/to/secrets/
              name: secrets
          volumes:
          - name: config
            configMap:
              name: sync
          - emptyDir:
              medium: memory
            name: secrets
```