### PR TITLE
feat(kubernetes-sync): Allow for Secret being provisioned by another tool

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.3.6
+version: 0.4.0
 appVersion: "0.4.7"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:

--- a/charts/kubernetes-sync/templates/cronjob.yaml
+++ b/charts/kubernetes-sync/templates/cronjob.yaml
@@ -35,9 +35,10 @@ spec:
               - {{ .Values.apitokenPath }}
               {{- end }}
             envFrom:
-            {{- if and .Values.apitokenSecret.create (not .Values.apitokenPath) }}
+            {{- if not .Values.apitokenPath }}
             - secretRef:
                 name: {{ .Values.apitokenSecret.name }}
+                optional: true
             {{- end }}
             resources:
               {{- toYaml .Values.resources | nindent 14 }}

--- a/charts/kubernetes-sync/templates/secret.yaml
+++ b/charts/kubernetes-sync/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apitokenSecret.create -}}
+{{- if .Values.apitoken -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -1,7 +1,6 @@
 apitoken:
 apitokenPath:
 apitokenSecret:
-  create: true
   name: api-token
 
 image: public.ecr.aws/opslevel/kubectl-opslevel:v0.4.7


### PR DESCRIPTION
This allows us to supply a secret using ExternalSecrets, and then reference it in the chart.

Alternatively, the [conditional here](https://github.com/OpsLevel/helm-charts/blob/main/charts/kubernetes-sync/templates/cronjob.yaml#L38) could be changed, so that the Secret is still referenced if not created

Testing:
```
mikebryant@BULB-MB-0246 kubernetes-sync % cat env.yaml
apitokenSecret:
  create: false
additionalEnvFrom:
- secretRef:
    name: flibble
mikebryant@BULB-MB-0246 kubernetes-sync % helm template . --values env.yaml | grep envFrom -A 5
            envFrom:
            - secretRef:
                name: flibble
            resources:
              {}
            securityContext:
mikebryant@BULB-MB-0246 kubernetes-sync %
```