### PR TITLE
fix(kubernetes-sync): Use the name of the ConfigMap that's created by default

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "0.4.7"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:

--- a/charts/kubernetes-sync/templates/cronjob.yaml
+++ b/charts/kubernetes-sync/templates/cronjob.yaml
@@ -53,7 +53,7 @@ spec:
           volumes:
           - name: config
             configMap:
-              name: sync
+              name: {{ template "opslevel-sync.fullname" . }}
           {{- with .Values.additionalVolumes }}
             {{- toYaml . | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
The names currently don't match up - with my release name of `opslevel-kubernetes-sync` the ConfigMap is called `opslevel-kubernetes-sync` but the CronJob references `sync`