### PR TITLE
fix: Set concurrencyPolicy

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.4.7"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:

--- a/charts/kubernetes-sync/templates/cronjob.yaml
+++ b/charts/kubernetes-sync/templates/cronjob.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  concurrencyPolicy: Forbid
   schedule: "{{ .Values.sync.schedule }}"
   jobTemplate:
     spec:


### PR DESCRIPTION
The CronJob should wait for the previous Job to finish, and not try to run the same sync in parallel

We're running it more frequently than is really sensible for some testing, and it's taking long enough to end up with more in parallel. This wouldn't normally be an issue - but I don't think we'd ever want this to end up with concurrent runs