### PR TITLE
fix: optional deployment value indent

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "0.6.6"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:

--- a/charts/kubernetes-sync/templates/deployment.yaml
+++ b/charts/kubernetes-sync/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: {{ include "opslevel-sync.serviceAccountName" . }}
       initContainers:
         {{- with .Values.additionalInitContainers }}
-          {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 6 }}
         {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -33,7 +33,7 @@ spec:
           - service
           - reconcile
           {{- with .Values.sync.args }}
-          {{- toYaml . | nindent 14 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- if .Values.apitokenPath }}
           - --api-token-path
@@ -47,34 +47,34 @@ spec:
         {{- end }}
         {{- with .Values.resources }}
         resources:
-          {{- toYaml . | nindent 14 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.securityContext }}
         securityContext:
-          {{- toYaml . | nindent 14 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: config
           mountPath: /app
         {{- with .Values.additionalVolumeMounts }}
-          {{- toYaml . | nindent 12 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ template "opslevel-sync.fullname" . }}
       {{- with .Values.additionalVolumes }}
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Fixes indents for some optional values in the deployment template. 
Looks like a hangover from the cronjob -> deployment change

Also un-indented initContainers/volumes/tolerations a littler further, to:
```
list:
- a
- b
```
from:
```
list:
  - a
  - b
```

in keeping with the rest of the manifest