### PR TITLE
Align implementation with example from the comment above

### DIFF
--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.5.8
+version: 0.5.9
 appVersion: "2022.10.19"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -44,7 +44,7 @@ sync:
               - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/tools"))) | map({"category": .key | split(".")[2], "displayName": .key | split(".")[3], "url": .value})'
             repositories: # attach repositories to the service using the opslevel repo alias - IE github.com:hashicorp/vault
               # find annotations with format: opslevel.com/repo.<displayname>.<repo.subpath.dots.turned.to.forwardslash>: <opslevel repo alias> 
-              - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repos"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
+              - '.metadata.annotations | to_entries |  map(select(.key | startswith("opslevel.com/repo"))) | map({"name": .key | split(".")[2], "directory": .key | split(".")[3:] | join("/"), "repo": .value})'
 
 serviceAccount:
   create: true


### PR DESCRIPTION
The comment in line 46 states it finds annotations starting with opslevel.com/repo

The implementation searches for annotations beginning with opslevel.com/repos (note the s at the end). This inconsistency means people using the format from the comment won't get the source code repos detected by opslevel.

This PR changes the implementation so it looks for the opslevel.com/repo prefix.
