### PR TITLE
release 0.6.3 by forcing deploy to set config to /app

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Issues
+
+<!-- paste an issue link here from github/gitlab -->
+
+## Changelog
+
+- [ ] List your changes here
+- [ ] Make a `changie` entry
+
+## Tophatting
+
+<!-- paste in CLI output, log messages or screenshots showing your change works -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/opslevel-k8s.yaml

--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubernetes-sync
 type: application
 version: 0.6.3
-appVersion: "2024.2.26"
-description: An agent for syncronizing Kubernetes data with OpsLevel
+appVersion: "v2024.3.4"
+description: An agent for synchronizing Kubernetes data with OpsLevel
 keywords:
 - monitoring
 - alerting

--- a/charts/kubernetes-sync/Chart.yaml
+++ b/charts/kubernetes-sync/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-sync
 type: application
-version: 0.6.2
+version: 0.6.3
 appVersion: "2024.2.26"
 description: An agent for syncronizing Kubernetes data with OpsLevel
 keywords:

--- a/charts/kubernetes-sync/README.md
+++ b/charts/kubernetes-sync/README.md
@@ -1,16 +1,50 @@
 Kubernetes Sync
 ---
 
-This chart packages up [kubectl-opslevel](https://github.com/OpsLevel/kubectl-opslevel) and runs it as a `deployment` using the command `service reconcile` to attach to the Kubernetes event stream for any create and update events.  These are then processed by the tool and resulting service data is sent OpsLevel.
+This chart for [kubectl-opslevel](https://github.com/OpsLevel/kubectl-opslevel) creates a deployment
+to run the app in the background using `$ kubectl-opslevel service reconcile`.
 
-Make sure you have the [OpsLevel Helm chart](https://github.com/OpsLevel/helm-charts) repository added then you can perform an install with:
+The app attaches to the Kubernetes event stream and listens for any create and update events.
+These are then processed by the tool and the resulting service data is sent OpsLevel.
+
+Make sure you have the [OpsLevel Helm chart](https://github.com/OpsLevel/helm-charts) repository added.
+
+## Deploy
+
+```bash
+# double check that you are in the correct cluster
+kctx
+
+# double check that your config file is correct
+cat opslevel-k8s.yaml
+
+# export API token and desired namespace (defaults to 'opslevel')
+ OPSLEVEL_API_TOKEN="..." NAMESPACE="..."
+
+#
+#   IF INSTALLING FOR THE FIRST TIME:
+#
+helm install sync opslevel/kubernetes-sync \
+    --namespace="${NAMESPACE:-opslevel}" \
+    --create-namespace \
+    --set-file sync.config=./opslevel-k8s.yaml \
+    --set apitoken="$OPSLEVEL_API_TOKEN"
+
+#
+#   RE-DEPLOYS:
+#
+helm upgrade sync opslevel/kubernetes-sync \
+    --namespace="${NAMESPACE:-opslevel}" \
+    --set-file sync.config=./opslevel-k8s.yaml \
+    --set apitoken="$OPSLEVEL_API_TOKEN"
+```
+
+## Deploy without using our public container registry
+
+To deploying using an image from your own registry, edit this line in [values.yaml](./values.yaml):
 
 ```
-helm install sync opslevel/kubernetes-sync --namespace=opslevel --create-namespace --set-file sync.config=./opslevel-k8s.yaml --set apitoken=XXXXX 
+image: public.ecr.aws/opslevel/kubectl-opslevel:v2024.2.26
 ```
 
-To upgrade
-
-```
-helm upgrade --namespace=opslevel --set-file sync.config=./opslevel-k8s.yaml --set apitoken=XXXXX sync opslevel/kubernetes-sync
-```
+and then deploy using `helm`.

--- a/charts/kubernetes-sync/README.md
+++ b/charts/kubernetes-sync/README.md
@@ -44,7 +44,7 @@ helm upgrade sync opslevel/kubernetes-sync \
 To deploying using an image from your own registry, edit this line in [values.yaml](./values.yaml):
 
 ```
-image: public.ecr.aws/opslevel/kubectl-opslevel:v2024.2.26
+image: public.ecr.aws/opslevel/kubectl-opslevel:v2024.3.4
 ```
 
 and then deploy using `helm`.

--- a/charts/kubernetes-sync/templates/deployment.yaml
+++ b/charts/kubernetes-sync/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
         args:
           - service
           - reconcile
+          - --config
+          - /app/opslevel-k8s.yaml
           {{- with .Values.sync.args }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -66,7 +66,7 @@ annotations:
   opslevel.com/description: "A tool that enables you to import & reconcile services with OpsLevel from your Kubernetes clusters."
   opslevel.com/language: "go"
   opslevel.com/framework: "client-go"
-  opslevel.com/tags.app_version: "v2024.1.27"
+  opslevel.com/tags.app_version: "v2024.2.26"
 securityContext: {}
 resources: {}
 nodeSelector: {}

--- a/charts/kubernetes-sync/values.yaml
+++ b/charts/kubernetes-sync/values.yaml
@@ -3,7 +3,7 @@ apitokenPath:
 apitokenSecret:
   name: opslevel-api-token
 
-image: public.ecr.aws/opslevel/kubectl-opslevel:v2024.2.26
+image: public.ecr.aws/opslevel/kubectl-opslevel:v2024.3.4
 
 sync:
   args:
@@ -66,7 +66,7 @@ annotations:
   opslevel.com/description: "A tool that enables you to import & reconcile services with OpsLevel from your Kubernetes clusters."
   opslevel.com/language: "go"
   opslevel.com/framework: "client-go"
-  opslevel.com/tags.app_version: "v2024.2.26"
+  opslevel.com/tags.app_version: "v2024.3.4"
 securityContext: {}
 resources: {}
 nodeSelector: {}


### PR DESCRIPTION
Should resolve: https://github.com/OpsLevel/team-platform/issues/243

## Explanation

Problem: when using the helm chart, unless the user explicitly chooses to use `--config /app/opslevel-k8s.yaml` (which is not obvious).

Solution: for now, adjust the chart to always making the deploy provide that option. **This way, customers don't need to make any changes to their config to get the program running.**

Also, customers who are specifying a different `--config $DIRECTORY` are perfectly fine because the option will override what's in the deployment.

```
$ kubectl-opslevel service import --config file1 --config file2
panic: open file2: no such file or directory
```

## Tophatting (on my own kind cluster)

```
# create template
helm template local-build-0.6.3 . > tmp.yaml

# apply template
$ k apply -f tmp.yaml
serviceaccount/opslevel-sync created
configmap/local-build-0.6.3-kubernetes-sync created
clusterrole.rbac.authorization.k8s.io/local-build-0.6.3-kubernetes-sync created
clusterrolebinding.rbac.authorization.k8s.io/sync created
Warning: metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: [must not contain dots]
deployment.apps/local-build-0.6.3-kubernetes-sync created

# apply secret (helm template does not make one but the actual chart will)
$ k apply -f tmp_secret.yaml
secret/opslevel-api-token created

# check pods - running fine!
$ kgp
NAME                                                 READY   STATUS    RESTARTS      AGE     IP            NODE                 NOMINATED NODE   READINESS GATES
local-build-0.6.3-kubernetes-sync-7ff85cf4cd-6l5wq   1/1     Running   1 (80s ago)   4m21s   10.244.0.21   kind-control-plane   <none>           <none>
```

## More details

1. We are indenting the config file too much
2. When the container starts, the working dir is `/go`

```
~/r/helm-charts/c/kubernetes-sync ta/fix-volume-bug ?2 ❯ k exec -it local-build-0.6.3-kubernetes-sync-7ff85cf4cd-6l5wq -- /bin/bash
root@local-build-0:/go# ls -la
total 16
drwxrwxrwt 4 root root 4096 Feb 13 13:07 .
drwxr-xr-x 1 root root 4096 Mar  2 01:02 ..
drwxrwxrwt 2 root root 4096 Feb 13 13:07 bin
drwxrwxrwt 2 root root 4096 Feb 13 13:07 src


root@local-build-0:/# cat app/opslevel-k8s.yaml
                                                     # empty space caused by newline
version: "1.3.0"                                     # this is correctly quoted.
service:
  import:
    - selector:
        apiVersion: apps/v1
        kind: Deployment
        excludes:                                           # indents are massive - should be 2 spaces.
            - .metadata.namespace == "kube-system"
            - .metadata.annotations."opslevel.com/ignore"
```

Some logs:

```
local-build-0.6.3-kubernetes-sync-74467cc6b4-2gt8x kubernetes-sync 1:16AM INF Handling interruption signal=terminated
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [apps/v1/deployments] Informer is ready and synced
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN unexpected happened: got service with alias 'k8s:local-build-0.6.3-kubernetes-sync-default' but the result has no ID
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN unexpected happened: got service with alias 'default-local-build-0.6.3-kubernetes-sync' but the result has no ID
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [local-build-0.6.3-kubernetes-sync] Unable to find 'Tier' with alias 'null'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [local-build-0.6.3-kubernetes-sync] Unable to find 'Lifecycle' with alias 'null'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [local-build-0.6.3-kubernetes-sync] Unable to find 'Team' with alias 'null'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-build-0.6.3-kubernetes-sync] Created new service
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-build-0.6.3-kubernetes-sync] Assigned alias 'k8s:local-build-0.6.3-kubernetes-sync-default'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-build-0.6.3-kubernetes-sync] Assigned alias 'default-local-build-0.6.3-kubernetes-sync'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-build-0.6.3-kubernetes-sync] Assigned tags: [{"key":"imported","value":"kubectl-opslevel"},{"key":"app_version","value":"v2024.2.26"},{"key":"helm.sh/chart","value":"kubernetes-sync-0.6.3"},{"key":"app.kubernetes.io/instance","value":"local-build-0.6.3"},{"key":"app.kubernetes.io/managed-by","value":"Helm"},{"key":"app.kubernetes.io/name","value":"kubernetes-sync"},{"key":"app.kubernetes.io/version","value":"2024.2.26"}]
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN unexpected happened: got service with alias 'k8s:nginx-opslevel-deployment-default' but the result has no ID
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN unexpected happened: got service with alias 'default-nginx-opslevel-deployment' but the result has no ID
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [nginx-opslevel-deployment] Unable to find 'Lifecycle' with alias 'beta'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [nginx-opslevel-deployment] Created new service
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [nginx-opslevel-deployment] Assigned alias 'k8s:nginx-opslevel-deployment-default'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [nginx-opslevel-deployment] Assigned alias 'default-nginx-opslevel-deployment'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [nginx-opslevel-deployment] Assigned tags: [{"key":"imported","value":"kubectl-opslevel"},{"key":"from_kubernetes","value":"True"},{"key":"hello","value":"world"},{"key":"image","value":"1.24"},{"key":"is_public","value":"True"},{"key":"vpc_enabled","value":"True"},{"key":"app","value":"nginx"}]
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN unexpected happened: got service with alias 'k8s:local-path-provisioner-local-path-storage' but the result has no ID
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN unexpected happened: got service with alias 'local-path-storage-local-path-provisioner' but the result has no ID
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [local-path-provisioner] Unable to find 'Tier' with alias 'null'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [local-path-provisioner] Unable to find 'Lifecycle' with alias 'null'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM WRN [local-path-provisioner] Unable to find 'Team' with alias 'null'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-path-provisioner] Created new service
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-path-provisioner] Assigned alias 'k8s:local-path-provisioner-local-path-storage'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-path-provisioner] Assigned alias 'local-path-storage-local-path-provisioner'
local-build-0.6.3-kubernetes-sync-79ffd95db5-4lznv kubernetes-sync 1:16AM INF [local-path-provisioner] Assigned tags: [{"key":"imported","value":"kubectl-opslevel"}]
^[[1;2Alocal-build-0.6.3-kubernetes-sync-74467cc6b4-2gt8x kubernetes-sync Error: client validation error: Message: Post "https://app.opslevel.com/graphql": POST https://app.opslevel.com/graphql giving up after 11 attempt(s): Post "https://app.opslevel.com/graphql": net/http: invalid header field value for "Authorization", Locations: [], Extensions: map[code:request_error], Path: []
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
for some reason my cluster's networking dies after a few seconds and can't send any more http requests, but here's the created service:

$ opslevel list service | grep -i local
local-build-0.6.3-kubernetes-sync                                 Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDY3MTA  default-local-build-0.6.3-kubernetes-sync,k8s:local-build-0.6.3-kubernetes-sync-default,local-build-0.6.3-kubernetes-sync,local-build-0_6_3-kubernetes-sync

$ opslevel get service Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDY3MTA
{
  "description": "A tool that enables you to import &amp; reconcile services with OpsLevel from your Kubernetes clusters.",
  "framework": "client-go",
  "htmlUrl": "https://app.opslevel.com/services/local-build-0_6_3-kubernetes-sync",
  "id": "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDY3MTA",
  "aliases": [
    "default-local-build-0.6.3-kubernetes-sync",
    "k8s:local-build-0.6.3-kubernetes-sync-default",
    "local-build-0.6.3-kubernetes-sync",
    "local-build-0_6_3-kubernetes-sync"
  ],
...
```