### PR TITLE
add missing changelogs from 0.6.3 release

### DIFF
--- a/.changes/unreleased/Bugfix-20240304-180812.yaml
+++ b/.changes/unreleased/Bugfix-20240304-180812.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug where config was not being read from the /app directory, causing the
+  program to crash
+time: 2024-03-04T18:08:12.471407-05:00

--- a/.changes/unreleased/Bugfix-20240304-180859.yaml
+++ b/.changes/unreleased/Bugfix-20240304-180859.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where the chart's appVersion was was written as '2024.3.4' and not 'v2024.3.4'
+time: 2024-03-04T18:08:59.637806-05:00

--- a/.changes/unreleased/Feature-20240304-180716.yaml
+++ b/.changes/unreleased/Feature-20240304-180716.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Bump kubernetes-sync version to v2024.3.4 (fixes version bug)
+time: 2024-03-04T18:07:16.346179-05:00


### PR DESCRIPTION
follow up to https://github.com/OpsLevel/helm-charts/pull/21

## side note

the current release workflow cannot kick off from github, does not do any changie work at all. current changelog is broken since last year Oct.

scheduled work to fix that here: https://github.com/OpsLevel/team-platform/issues/261