### PR TITLE
Bugfix for github app install url rendering

### DIFF
--- a/.changes/unreleased/Bugfix-20240628-110042.yaml
+++ b/.changes/unreleased/Bugfix-20240628-110042.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug with rendering github install url
+time: 2024-06-28T11:00:42.066602-05:00

--- a/charts/opslevel/templates/_helpers.tpl
+++ b/charts/opslevel/templates/_helpers.tpl
@@ -44,7 +44,7 @@
 {{- end }}
 
 {{- define "github.install.url" -}}
-https://github.com/apps/{{ .Values.integrations.github.secret.app_name | urlquery }}/installations/new
+https://github.com/apps/{{ required "please provide 'integrations.github.secret.appName'" .Values.integrations.github.secret.appName | urlquery }}/installations/new
 {{- end }}
 
 {{- define "opslevel.image" -}}

--- a/charts/opslevel/templates/opslevel/secret.yaml
+++ b/charts/opslevel/templates/opslevel/secret.yaml
@@ -81,8 +81,7 @@ data:
   GITHUB_APP_IDENTIFIER: '{{ required "please provide 'integrations.github.secret.appId'" .Values.integrations.github.secret.appId | b64enc }}'
   GITHUB_PRIVATE_KEY: '{{ required "please provide 'integrations.github.secret.privateKey'" .Values.integrations.github.secret.privateKey | b64enc }}'
   GITHUB_WEBHOOK_SECRET: '{{ required "please provide 'integrations.github.secret.webhookSecret'" .Values.integrations.github.secret.webhookSecret | b64enc }}'
-stringData:
-  GITHUB_INSTALL_URL: '{{ template "github.install.url" . }}'
+  GITHUB_INSTALL_URL: '{{ include "github.install.url" . | b64enc }}'
 {{- end }}
 {{- end }}
 

--- a/charts/opslevel/templates/opslevel/secret.yaml
+++ b/charts/opslevel/templates/opslevel/secret.yaml
@@ -81,7 +81,8 @@ data:
   GITHUB_APP_IDENTIFIER: '{{ required "please provide 'integrations.github.secret.appId'" .Values.integrations.github.secret.appId | b64enc }}'
   GITHUB_PRIVATE_KEY: '{{ required "please provide 'integrations.github.secret.privateKey'" .Values.integrations.github.secret.privateKey | b64enc }}'
   GITHUB_WEBHOOK_SECRET: '{{ required "please provide 'integrations.github.secret.webhookSecret'" .Values.integrations.github.secret.webhookSecret | b64enc }}'
-  GITHUB_INSTALL_URL: '{{ template "github.install.url" . | b64enc }}'
+stringData:
+  GITHUB_INSTALL_URL: '{{ template "github.install.url" . }}'
 {{- end }}
 {{- end }}
 

--- a/charts/opslevel/values.yaml
+++ b/charts/opslevel/values.yaml
@@ -192,7 +192,7 @@ objectStorage:
 smtp:
   enabled: false
   secret:
-    create: false
+    create: true
     name: "opslevel-smtp"
     emailDisplayName: "opslevel"
     emailDomain: ""


### PR DESCRIPTION
## Issues

Fixes

```
Error: template: opslevel/templates/opslevel/worker-low.yaml:27:28: executing "opslevel/templates/opslevel/worker-low.yaml" at <include (print $.Template.BasePath "/opslevel/secret.yaml") .>: error calling include: template: opslevel/templates/opslevel/secret.yaml:84:60: executing "opslevel/templates/opslevel/secret.yaml" at <b64enc>: wrong type for value; expected string; got chartutil.Values
```
