### PR TITLE
Add ability to specify annotations on service accounts

### DIFF
--- a/charts/opslevel/templates/elasticsearch/serviceaccount.yaml
+++ b/charts/opslevel/templates/elasticsearch/serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: serviceAccount
     app.kubernetes.io/part-of: elasticsearch
+{{- with .Values.elasticsearch.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/opslevel/templates/minio/serviceaccount.yaml
+++ b/charts/opslevel/templates/minio/serviceaccount.yaml
@@ -7,5 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/component: serviceAccount
     app.kubernetes.io/part-of: minio
+{{- with .Values.objectStorage.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/opslevel/templates/mysql/serviceaccount.yaml
+++ b/charts/opslevel/templates/mysql/serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: serviceAccount
     app.kubernetes.io/part-of: mysql
+{{- with .Values.mysql.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/opslevel/templates/opslevel/service.yaml
+++ b/charts/opslevel/templates/opslevel/service.yaml
@@ -1,10 +1,15 @@
+{{- if .Values.opslevel.service.create }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: opslevel
+  name: {{ .Values.opslevel.service.name }}
   labels:
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: opslevel
+{{- with .Values.opslevel.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: http
@@ -13,4 +18,4 @@ spec:
   selector:
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: opslevel
-
+{{- end }}

--- a/charts/opslevel/templates/postgres/serviceaccount.yaml
+++ b/charts/opslevel/templates/postgres/serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: serviceAccount
     app.kubernetes.io/part-of: postgres
+{{- with .Values.postgres.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/opslevel/templates/runner/new-mode.yaml
+++ b/charts/opslevel/templates/runner/new-mode.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       {{- template "global.nodeSelector" . }}
       priorityClassName: opslevel-normal
-      serviceAccountName: opslevel-runner
+      serviceAccountName: {{ .Values.runner.serviceAccount.name }}
       {{- if .Values.certificate.enabled }}
       initContainers:
         - name: init-certs

--- a/charts/opslevel/templates/runner/old-mode.yaml
+++ b/charts/opslevel/templates/runner/old-mode.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       {{- template "global.nodeSelector" . }}
       priorityClassName: opslevel-normal
-      serviceAccountName: opslevel-runner
+      serviceAccountName: {{ .Values.runner.serviceAccount.name }}
       {{- if .Values.certificate.enabled }}
       initContainers:
         - name: init-certs

--- a/charts/opslevel/templates/runner/rbac.yaml
+++ b/charts/opslevel/templates/runner/rbac.yaml
@@ -12,7 +12,6 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/opslevel/templates/runner/rbac.yaml
+++ b/charts/opslevel/templates/runner/rbac.yaml
@@ -1,11 +1,18 @@
 {{- if .Values.runner.enabled }}
+{{- if .Values.runner.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: opslevel-runner
+  name: {{ .Values.runner.serviceAccount.name }}
   labels:
     app.kubernetes.io/component: serviceAccount
     app.kubernetes.io/part-of: runner
+{{- with .Values.runner.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/opslevel/values.yaml
+++ b/charts/opslevel/values.yaml
@@ -54,6 +54,10 @@ opslevel:
   workerLow:
     replicas: 2
     resources: *resourcesMedium
+  service:
+    create: true
+    name: "opslevel" &opslevel_service_name
+    annotations: {}
   secret:
     name: "opslevel"
     create: true
@@ -71,6 +75,10 @@ runner:
     tag: "v2024.10.14"
   replicas: 3
   resources: *resourcesLarge
+  serviceAccount:
+    create: true
+    name: opslevel-runner
+    annotations: {}
   secret:
     name: "opslevel-runner"
     create: true
@@ -101,6 +109,7 @@ mysql:
   serviceAccount:
     create: true
     name: mysql
+    annotations: {}
   storageClass: ""
   storageSize: "10Gi"
   secret:
@@ -121,6 +130,7 @@ postgres:
   serviceAccount:
     create: true
     name: postgres
+    annotations: {}
   storageClass: ""
   storageSize: "10Gi"
   secret:
@@ -156,6 +166,7 @@ elasticsearch:
   serviceAccount:
     create: true
     name: elasticsearch
+    annotations: {}
   storageClass: ""
   storageSize: "8Gi"
   secret:
@@ -178,6 +189,7 @@ objectStorage:
   serviceAccount:
     create: true
     name: minio
+    annotations: {}
   storageClass: ""
   storageSize: "8Gi"
   secret:


### PR DESCRIPTION
## Issues

All for service account annotations to be given and service resource annotations.  We still need to allow annotations on the different container template specs - coming in a future PR.

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
