### PR TITLE
Make security context configurable where previously it was not

### DIFF
--- a/.changes/unreleased/Feature-20250512-143537.yaml
+++ b/.changes/unreleased/Feature-20250512-143537.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to set security context on postgres and elasticsearch
+time: 2025-05-12T14:35:37.645939-05:00

--- a/charts/opslevel/templates/elasticsearch/statefulset.yaml
+++ b/charts/opslevel/templates/elasticsearch/statefulset.yaml
@@ -28,8 +28,10 @@ spec:
       {{- template "global.nodeSelector" . }}
       serviceAccountName: "{{ .Values.elasticsearch.serviceAccount.name }}"
       priorityClassName: opslevel-high
+      {{- with .Values.elasticsearch.securityContext }}
       securityContext:
-        fsGroup: 0
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       subdomain: elasticsearch
       containers:
         - name: elasticsearch

--- a/charts/opslevel/templates/postgres/statefulset.yaml
+++ b/charts/opslevel/templates/postgres/statefulset.yaml
@@ -32,8 +32,10 @@ spec:
       {{- template "global.nodeSelector" . }}
       serviceAccountName: "{{ .Values.postgres.serviceAccount.name }}"
       priorityClassName: opslevel-high
+      {{- with .Values.postgres.securityContext }}
       securityContext:
-        fsGroup: 1001
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: false
       hostIPC: false
       containers:

--- a/charts/opslevel/values.yaml
+++ b/charts/opslevel/values.yaml
@@ -155,6 +155,8 @@ postgres:
     create: true
     name: postgres
     annotations: {}
+  securityContext:
+    fsGroup: 1001
   storageClass: ""
   storageSize: "10Gi"
   secret:
@@ -195,6 +197,8 @@ elasticsearch:
     create: true
     name: elasticsearch
     annotations: {}
+  securityContext:
+    fsGroup: 0
   storageClass: ""
   storageSize: "8Gi"
   secret:


### PR DESCRIPTION
## Issues

A customer is trying to use openshift and they need to configure the security contexts. 

So this makes them fully configurable

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

