### PR TITLE
Add emptydir config for the make-bucket script for the mc commandline to fix a bug

### DIFF
--- a/charts/opslevel/templates/minio/configmap.yaml
+++ b/charts/opslevel/templates/minio/configmap.yaml
@@ -11,10 +11,10 @@ data:
     #! /usr/bin/env bash
     trap "echo [opslevel] Terminated TERM; exit" SIGTERM
     while true; do
-      mc --config-dir /config config host add opslevel http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
-      mc --config-dir /config ready opslevel
-      mc --config-dir /config mb --ignore-existing opslevel/${MINIO_BUCKET_NAME}
-      mc --config-dir /config anonymous set public opslevel/${MINIO_BUCKET_NAME}
+      mc --config-dir /opslevel_config config host add opslevel http://minio.{{ .Release.Namespace }}.svc.cluster.local:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
+      mc --config-dir /opslevel_config ready opslevel
+      mc --config-dir /opslevel_config mb --ignore-existing opslevel/${MINIO_BUCKET_NAME}
+      mc --config-dir /opslevel_config anonymous set public opslevel/${MINIO_BUCKET_NAME}
       sleep 600 &
       wait $!
     done;

--- a/charts/opslevel/templates/minio/create-bucket.yaml
+++ b/charts/opslevel/templates/minio/create-bucket.yaml
@@ -34,7 +34,7 @@ spec:
           - name: scripts
             mountPath: /opslevel
           - name: config
-            mountPath: /config
+            mountPath: /opslevel_config
       volumes:
         - name: scripts
           configMap:


### PR DESCRIPTION
Resolves #

### Problem

When in a readonly filesystem cluster the script fails to write the config file for the mc commandline tool

### Solution

Add  an empty dir mounted and use that location

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] Make a [changie](https://changie.dev/guide/quick_start/) entry that explains the customer facing outcome of this change