### PR TITLE
Increase default worker-high resourcing

### DIFF
--- a/.changes/unreleased/Feature-20260204-110859.yaml
+++ b/.changes/unreleased/Feature-20260204-110859.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: 'Bump default opslevel.workerHigh.resources from small (200m CPU / 500Mi memory requests) to medium (1 CPU / 2Gi memory requests) '
+time: 2026-02-04T11:08:59.849632-08:00

--- a/charts/opslevel/values.yaml
+++ b/charts/opslevel/values.yaml
@@ -54,7 +54,7 @@ opslevel:
     maxWebhookPayloadSize: 0
   workerHigh:
     replicas: 2
-    resources: *resourcesSmall
+    resources: *resourcesMedium
   workerLow:
     replicas: 2
     resources: *resourcesMedium


### PR DESCRIPTION
Bump default opslevel.workerHigh.resources from small (200m CPU / 500Mi memory requests) to medium (1 CPU / 2Gi memory requests) so high-priority Sidekiq workers have enough CPU and memory to avoid restarts and degraded deployments on typical self-hosted installs.

### Problem

We are seeing degraded performance of one customer's `worker-high` deployment.

### Solution

We already use `resourcesMedium` for our `worker-low` deployment, there's no reason we should be allocating less to our high priority workloads. Bumps resourcing from small (200m CPU / 500Mi memory requests) to medium (1 CPU / 2Gi memory requests).

I had AI help outline our current resource requests:

Component | Pods | CPU (req) | Memory (req)
-- | -- | -- | --
OpsLevel web | 3 | 3 | 6 Gi
worker-high | 2 | 2 (was 0.4) | 4 Gi (was 1 Gi)
worker-low | 2 | 2 | 4 Gi
scheduler | 1 | 1 | 2 Gi
worker-faktory | 1 | 1 | 2 Gi
worker-search | 1 | 1 | 2 Gi
Opssight web | 1 | 1 | 2 Gi
Opssight worker | 1 | 0.2 | 0.5 Gi
MySQL | 1 | 1 | 2 Gi
Postgres | 1 | 1 | 2 Gi
Redis | 1 | 1 | 2 Gi
Elasticsearch | 1 | 2 | 2 Gi
MinIO | 4 | 4 | 8 Gi
Faktory | 1 | 1 | 2 Gi
Total | 21 | ~21.2 (was ~19.6) | ~40.5 Gi (was ~37.5 Gi)


Comparing this back to our documented [Resource Requirements](https://docs.opslevel.com/docs/getting-started-with-self-hosted-opslevel#cluster-requirements):

```
The Kubernetes cluster must meet the following minimum specifications:

    CPU: 16 cores
    Memory: 20 GB RAM
    Pods: Capacity for at least 20 pods
    Disk Storage: Minimum of 120 GiB (may be lower if the production database is hosted elsewhere)
```

It seems like our recommended minimums have been well below the current requirements. Am I missing something here, or do the docs need updated?