### PR TITLE
fix: redis clients unable to perform write commands

### DIFF
--- a/charts/opslevel/values.yaml
+++ b/charts/opslevel/values.yaml
@@ -217,7 +217,8 @@ redis:
     create: true
     name: redis
     annotations: {}
-  securityContext: {}
+  securityContext:
+    fsGroup: 999
   #    fsGroupChangePolicy: Always
   #    supplementalGroups: []
   #    sysctls: []


### PR DESCRIPTION
sets redis securityContext.fsGroup

Fixes the following error (redis clients stack tracing; pods loopcrashing)

> MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error. (redis://redis:6379)

The image entrypoint drops to uid 999, but the PVC is mounted root-owned with no fsGroup set.

```
>  kubectl logs -f opslevel-worker-high-7b49c55565-k55s7
[...]
MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error. (redis://redis:6379)
/home/opslevel/vendor/ruby/3.3.0/gems/redis-client-0.29.0/lib/redis_client/connection_mixin.rb:43:in `call'
/home/opslevel/vendor/ruby/3.3.0/gems/redis-client-0.29.0/lib/redis_client.rb:365:in `block (2 levels) in call'
/home/opslevel/vendor/ruby/3.3.0/gems/redis-client-0.29.0/lib/redis_client/middlewares.rb:16:in `call'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing/contrib/redis/trace_middleware.rb:17:in `block in call'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing/contrib/redis/trace_middleware.rb:34:in `block in call'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing/tracer.rb:548:in `skip_trace'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing/tracer.rb:145:in `trace'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing.rb:29:in `trace'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing/contrib/redis/trace_middleware.rb:28:in `call'
/home/opslevel/vendor/ruby/3.3.0/gems/datadog-2.15.0/lib/datadog/tracing/contrib/redis/trace_middleware.rb:17:in `call'
/home/opslevel/vendor/ruby/3.3.0/gems/redis-client-0.29.0/lib/redis_client.rb:364:in `block in call'
/home/opslevel/vendor/ruby/3.3.0/gems/redis-client-0.29.0/lib/redis_client.rb:787:in `ensure_connected'
/home/opslevel/vendor/ruby/3.3.0/gems/redis-client-0.29.0/lib/redis_client.rb:363:in `call'
/home/opslevel/vendor/ruby/3.3.0/gems/sidekiq-8.1.3/lib/sidekiq/redis_client_adapter.rb:35:in `block (2 levels) in <module:CompatMethods>'
/home/opslevel/vendor/ruby/3.3.0/gems/sidekiq-scheduler-6.0.2/lib/sidekiq-scheduler/redis_manager.rb:238:in `block in hdel'
/home/opslevel/vendor/ruby/3.3.0/gems/sidekiq-8.1.3/lib/sidekiq/config.rb:190:in `block in redis'
/home/opslevel/vendor/ruby/3.3.0/gems/connection_pool-3.0.2/lib/connection_pool.rb:68:in `block (2 levels) in with'
/home/opslevel/vendor/ruby/3.3.0/gems/connection_pool-3.0.2/lib/connection_pool.rb:67:in `handle_interrupt'
/home/opslevel/vendor/ruby/3.3.0/gems/connection_pool-3.0.2/lib/connection_pool.rb:67:in `block in with'
/home/opslevel/vendor/ruby/3.3.0/gems/connection_pool-3.0.2/lib/connection_pool.rb:64:in `handle_interrupt'
/home/opslevel/vendor/ruby/3.3.0/gems/connection_pool-3.0.2/lib/connection_pool.rb:64:in `with'
/home/opslevel/vendor/ruby/3.3.0/gems/sidekiq-8.1.3/lib/sidekiq/config.rb:187:in `redis'
/home/opslevel/vendor/ruby/3.3.0/gems/sidekiq-8.1.3/lib/sidekiq.rb:82:in `redis'
```
