### PR TITLE
reduce pilot deployment footprint

### DIFF
--- a/charts/opslevel/values.yaml
+++ b/charts/opslevel/values.yaml
@@ -49,7 +49,7 @@ opslevel:
   pod:
     annotations: {}
   web:
-    replicas: 3
+    replicas: 2
     resources: *resourcesMedium
     # limits webhook payload size accepted by Rails (bytes)
     maxWebhookPayloadSize: 0
@@ -96,7 +96,7 @@ runner:
     digest: "sha256:048597926fffe2af850e607c509fc396fc73fa7bf46594c2f9b2fcbb452bfdab"
   job_image:
     repository: "public.ecr.aws/opslevel"
-  replicas: 3
+  replicas: 2
   resources: *resourcesLarge
   serviceAccount:
     create: true


### PR DESCRIPTION
reduce `web` and `opslevel-runner` deployment default replicas for pilot from 3 to 2

### Problem

Workload is cpu constrained. Deploying pilot on 22.5 available cores. This change alone is not sufficient to solve the problem entirely but is one step in the right direction